### PR TITLE
Add ApiVersion class to get & check for api compatability

### DIFF
--- a/base/src/main/java/org/geysermc/api/GeyserApiBase.java
+++ b/base/src/main/java/org/geysermc/api/GeyserApiBase.java
@@ -117,7 +117,7 @@ public interface GeyserApiBase {
 
     /**
      * Returns the major API version. Bumped whenever a significant breaking change or feature addition is added.
-     * Deprecated in favor of {@link #baseApiVersion()}.
+     * @deprecated in favor of {@link #baseApiVersion()}.
      */
     @Deprecated
     default int majorApiVersion() {
@@ -126,7 +126,7 @@ public interface GeyserApiBase {
 
     /**
      * Returns the minor API version. May be bumped for new API additions.
-     * Deprecated in favor of {@link #baseApiVersion()}.
+     * @deprecated in favor of {@link #baseApiVersion()}.
      */
     @Deprecated
     default int minorApiVersion() {

--- a/base/src/main/java/org/geysermc/api/GeyserApiBase.java
+++ b/base/src/main/java/org/geysermc/api/GeyserApiBase.java
@@ -121,7 +121,7 @@ public interface GeyserApiBase {
      */
     @Deprecated
     default int majorApiVersion() {
-        return 1;
+        return baseApiVersion().major();
     }
 
     /**
@@ -130,7 +130,7 @@ public interface GeyserApiBase {
      */
     @Deprecated
     default int minorApiVersion() {
-        return 0;
+        return baseApiVersion().minor();
     }
 
     /**

--- a/base/src/main/java/org/geysermc/api/GeyserApiBase.java
+++ b/base/src/main/java/org/geysermc/api/GeyserApiBase.java
@@ -30,6 +30,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.IntRange;
 import org.geysermc.api.connection.Connection;
+import org.geysermc.api.util.ApiVersion;
 import org.geysermc.cumulus.form.Form;
 import org.geysermc.cumulus.form.util.FormBuilder;
 
@@ -116,15 +117,27 @@ public interface GeyserApiBase {
 
     /**
      * Returns the major API version. Bumped whenever a significant breaking change or feature addition is added.
+     * Deprecated in favor of {@link #baseApiVersion()}.
      */
+    @Deprecated
     default int majorApiVersion() {
         return 1;
     }
 
     /**
      * Returns the minor API version. May be bumped for new API additions.
+     * Deprecated in favor of {@link #baseApiVersion()}.
      */
+    @Deprecated
     default int minorApiVersion() {
         return 0;
+    }
+
+    /**
+     * Returns the Base API version.
+     * @return {@link ApiVersion}
+     */
+    default ApiVersion baseApiVersion() {
+        return new ApiVersion(1 ,0 ,0);
     }
 }

--- a/base/src/main/java/org/geysermc/api/GeyserApiBase.java
+++ b/base/src/main/java/org/geysermc/api/GeyserApiBase.java
@@ -117,6 +117,7 @@ public interface GeyserApiBase {
 
     /**
      * Returns the major API version. Bumped whenever a significant breaking change or feature addition is added.
+     *
      * @deprecated in favor of {@link #baseApiVersion()}.
      */
     @Deprecated
@@ -126,6 +127,7 @@ public interface GeyserApiBase {
 
     /**
      * Returns the minor API version. May be bumped for new API additions.
+     *
      * @deprecated in favor of {@link #baseApiVersion()}.
      */
     @Deprecated
@@ -135,6 +137,7 @@ public interface GeyserApiBase {
 
     /**
      * Returns the Base API version.
+     *
      * @return {@link ApiVersion}
      */
     default ApiVersion baseApiVersion() {

--- a/base/src/main/java/org/geysermc/api/GeyserApiBase.java
+++ b/base/src/main/java/org/geysermc/api/GeyserApiBase.java
@@ -141,6 +141,6 @@ public interface GeyserApiBase {
      * @return {@link ApiVersion}
      */
     default ApiVersion baseApiVersion() {
-        return new ApiVersion(1 ,0 ,0);
+        return new ApiVersion(1, 0, 0);
     }
 }

--- a/base/src/main/java/org/geysermc/api/util/ApiVersion.java
+++ b/base/src/main/java/org/geysermc/api/util/ApiVersion.java
@@ -37,10 +37,10 @@ public class ApiVersion {
 
     /**
      * Checks whether the given version is compatible with this version.
-     * @param version the version to check
+     * @param version the version to check against
      * @return whether the given version is compatible with this version
      */
     public boolean isCompatible(ApiVersion version) {
-        return version.major() != this.major && version.minor() > minor;
+        return version.major() != this.major && version.minor() >= minor;
     }
 }

--- a/base/src/main/java/org/geysermc/api/util/ApiVersion.java
+++ b/base/src/main/java/org/geysermc/api/util/ApiVersion.java
@@ -47,9 +47,10 @@ public class ApiVersion {
      *
      * @param major the major version to check against
      * @param minor the minor version to check against
+     * @param patch the patch version to check against
      * @return whether the desired API version is compatible with the present API version
      */
-    public boolean isCompatible(int major, int minor) {
-        return major == this.major && minor <= this.minor;
+    public boolean isCompatible(int major, int minor, int patch) {
+        return major == this.major && minor <= this.minor && patch <= this.patch;
     }
 }

--- a/base/src/main/java/org/geysermc/api/util/ApiVersion.java
+++ b/base/src/main/java/org/geysermc/api/util/ApiVersion.java
@@ -43,11 +43,13 @@ public class ApiVersion {
 
     /**
      * Checks whether the given version is compatible with this version.
+     * The parameters show the desired API version, that is checked against the API version present.
      *
-     * @param version the version to check against
-     * @return whether the given version is compatible with this version
+     * @param major the major version to check against
+     * @param minor the minor version to check against
+     * @return whether the desired API version is compatible with the present API version
      */
-    public boolean isCompatible(ApiVersion version) {
-        return version.major() != this.major && version.minor() >= minor;
+    public boolean isCompatible(int major, int minor) {
+        return major == this.major && minor <= this.minor;
     }
 }

--- a/base/src/main/java/org/geysermc/api/util/ApiVersion.java
+++ b/base/src/main/java/org/geysermc/api/util/ApiVersion.java
@@ -1,0 +1,46 @@
+package org.geysermc.api.util;
+
+public class ApiVersion {
+    private final int major;
+    private final int minor;
+    private final int patch;
+
+    public ApiVersion(int major, int minor, int patch) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
+
+    /**
+     * Returns the major version of the api.
+     * @return the major version
+     */
+    public int major() {
+        return this.major;
+    }
+
+    /**
+     * Returns the minor version of the api.
+     * @return the minor version
+     */
+    public int minor() {
+        return this.minor;
+    }
+
+    /**
+     * Returns the patch version of the api.
+     * @return the patch version
+     */
+    public int patch() {
+        return this.patch;
+    }
+
+    /**
+     * Checks whether the given version is compatible with this version.
+     * @param version the version to check
+     * @return whether the given version is compatible with this version
+     */
+    public boolean isCompatible(ApiVersion version) {
+        return version.major() != this.major && version.minor() > minor;
+    }
+}

--- a/base/src/main/java/org/geysermc/api/util/ApiVersion.java
+++ b/base/src/main/java/org/geysermc/api/util/ApiVersion.java
@@ -1,5 +1,8 @@
 package org.geysermc.api.util;
 
+/**
+ * Represents a version of the api.
+ */
 public class ApiVersion {
     private final int major;
     private final int minor;
@@ -13,6 +16,7 @@ public class ApiVersion {
 
     /**
      * Returns the major version of the api.
+     *
      * @return the major version
      */
     public int major() {
@@ -21,6 +25,7 @@ public class ApiVersion {
 
     /**
      * Returns the minor version of the api.
+     *
      * @return the minor version
      */
     public int minor() {
@@ -29,6 +34,7 @@ public class ApiVersion {
 
     /**
      * Returns the patch version of the api.
+     *
      * @return the patch version
      */
     public int patch() {
@@ -37,6 +43,7 @@ public class ApiVersion {
 
     /**
      * Checks whether the given version is compatible with this version.
+     *
      * @param version the version to check against
      * @return whether the given version is compatible with this version
      */

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 baseApiVersion=1.0.0-SNAPSHOT
-geyserApiVersion=1.0.1-SNAPSHOT
 
 org.gradle.caching=true
 org.gradle.parallel=true


### PR DESCRIPTION
Hey! To make extensions specify a geyser api version instead of a base api one, here are my proposed changes:
- deprecated old version methods
- added ApiVersion class w/ built in version check
- yeet unused geyserApiVersion=1.0.1-SNAPSHOT from gradle.properties