### PR TITLE
Switch to JSpecify for nullability annotations

### DIFF
--- a/.idea/copyright/Geyser.xml
+++ b/.idea/copyright/Geyser.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+    <copyright>
+        <option name="allowReplaceRegexp" value="Copyright" />
+        <option name="notice" value="Copyright (c) &amp;#36;originalComment.match(&quot;Copyright \(c\) (\d+)&quot;, 1, &quot;-&quot;)&amp;#36;today.year GeyserMC. http://geysermc.org&#10;&#10;Permission is hereby granted, free of charge, to any person obtaining a copy&#10;of this software and associated documentation files (the &quot;Software&quot;), to deal&#10;in the Software without restriction, including without limitation the rights&#10;to use, copy, modify, merge, publish, distribute, sublicense, and/or sell&#10;copies of the Software, and to permit persons to whom the Software is&#10;furnished to do so, subject to the following conditions:&#10;&#10;The above copyright notice and this permission notice shall be included in&#10;all copies or substantial portions of the Software.&#10;&#10;THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR&#10;IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,&#10;FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE&#10;AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER&#10;LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,&#10;OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN&#10;THE SOFTWARE.&#10;&#10;@author GeyserMC&#10;@link https://github.com/GeyserMC/Geyser" />
+        <option name="myName" value="Geyser" />
+    </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,7 @@
+<component name="CopyrightManager">
+    <settings>
+        <module2copyright>
+            <element module="All" copyright="Geyser" />
+        </module2copyright>
+    </settings>
+</component>

--- a/base/build.gradle.kts
+++ b/base/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 
 dependencies {
     api(libs.checker.qual)
+    api(libs.jspecify)
     api(libs.cumulus)
     api(libs.events) {
         exclude(group = "com.google.guava", module = "guava")

--- a/base/src/main/java/org/geysermc/api/Geyser.java
+++ b/base/src/main/java/org/geysermc/api/Geyser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/base/src/main/java/org/geysermc/api/Geyser.java
+++ b/base/src/main/java/org/geysermc/api/Geyser.java
@@ -25,21 +25,19 @@
 
 package org.geysermc.api;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
+import org.jspecify.annotations.Nullable;
 
 /**
  * General API class for Geyser.
  */
-@NonNull
 public class Geyser {
-    private static GeyserApiBase api;
+    private static @Nullable GeyserApiBase api;
 
     /**
      * Returns the base api.
      *
      * @return the base api
      */
-    @NonNull
     public static GeyserApiBase api() {
         if (api == null) {
             throw new RuntimeException("Api has not been registered yet!");
@@ -56,7 +54,7 @@ public class Geyser {
      * @return the api of the given type
      */
     @SuppressWarnings("unchecked")
-    public static <T extends GeyserApiBase> T api(@NonNull Class<T> apiClass) {
+    public static <T extends GeyserApiBase> T api(Class<T> apiClass) {
         if (apiClass.isInstance(api)) {
             return (T) api;
         }
@@ -75,7 +73,7 @@ public class Geyser {
      *
      * @param api the api
      */
-    public static void set(@NonNull GeyserApiBase api) {
+    public static void set(GeyserApiBase api) {
         if (Geyser.api != null) {
             throw new RuntimeException("Cannot redefine already registered api!");
         }

--- a/base/src/main/java/org/geysermc/api/GeyserApiBase.java
+++ b/base/src/main/java/org/geysermc/api/GeyserApiBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/base/src/main/java/org/geysermc/api/GeyserApiBase.java
+++ b/base/src/main/java/org/geysermc/api/GeyserApiBase.java
@@ -26,13 +26,12 @@
 package org.geysermc.api;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.common.value.qual.IntRange;
 import org.geysermc.api.connection.Connection;
 import org.geysermc.api.util.ApiVersion;
 import org.geysermc.cumulus.form.Form;
 import org.geysermc.cumulus.form.util.FormBuilder;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.UUID;
@@ -48,8 +47,7 @@ public interface GeyserApiBase {
      * @param uuid the UUID of the connection
      * @return the connection from the given UUID, if applicable
      */
-    @Nullable
-    Connection connectionByUuid(@NonNull UUID uuid);
+    @Nullable Connection connectionByUuid(UUID uuid);
 
     /**
      * Gets the connection from the given XUID, if applicable. This method only works for online connections.
@@ -57,8 +55,7 @@ public interface GeyserApiBase {
      * @param xuid the XUID of the session
      * @return the connection from the given UUID, if applicable
      */
-    @Nullable
-    Connection connectionByXuid(@NonNull String xuid);
+    @Nullable Connection connectionByXuid(String xuid);
 
     /**
      * Method to determine if the given <b>online</b> player is a Bedrock player.
@@ -66,7 +63,7 @@ public interface GeyserApiBase {
      * @param uuid the uuid of the online player
      * @return true if the given online player is a Bedrock player
      */
-    boolean isBedrockPlayer(@NonNull UUID uuid);
+    boolean isBedrockPlayer(UUID uuid);
 
     /**
      * Sends a form to the given connection and opens it.
@@ -75,7 +72,7 @@ public interface GeyserApiBase {
      * @param form the form to send
      * @return whether the form was successfully sent
      */
-    boolean sendForm(@NonNull UUID uuid, @NonNull Form form);
+    boolean sendForm(UUID uuid, Form form);
 
     /**
      * Sends a form to the given connection and opens it.
@@ -84,7 +81,7 @@ public interface GeyserApiBase {
      * @param formBuilder the formBuilder to send
      * @return whether the form was successfully sent
      */
-    boolean sendForm(@NonNull UUID uuid, @NonNull FormBuilder<?, ?, ?> formBuilder);
+    boolean sendForm(UUID uuid, FormBuilder<?, ?, ?> formBuilder);
 
     /**
      * Transfer the given connection to a server. A Bedrock player can successfully transfer to the same server they are
@@ -95,12 +92,11 @@ public interface GeyserApiBase {
      * @param port    the port of the server
      * @return true if the transfer was a success
      */
-    boolean transfer(@NonNull UUID uuid, @NonNull String address, @IntRange(from = 0, to = 65535) int port);
+    boolean transfer(UUID uuid, String address, @IntRange(from = 0, to = 65535) int port);
 
     /**
      * Returns all the online connections.
      */
-    @NonNull
     List<? extends Connection> onlineConnections();
 
     /**

--- a/base/src/main/java/org/geysermc/api/connection/Connection.java
+++ b/base/src/main/java/org/geysermc/api/connection/Connection.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/base/src/main/java/org/geysermc/api/connection/Connection.java
+++ b/base/src/main/java/org/geysermc/api/connection/Connection.java
@@ -26,7 +26,6 @@
 package org.geysermc.api.connection;
 
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.common.value.qual.IntRange;
 import org.geysermc.api.util.BedrockPlatform;
 import org.geysermc.api.util.InputMode;
@@ -43,7 +42,7 @@ public interface Connection {
     /**
      * Returns the bedrock name of the connection.
      */
-    @NonNull String bedrockUsername();
+    String bedrockUsername();
 
     /**
      * Returns the java name of the connection.
@@ -60,32 +59,32 @@ public interface Connection {
     /**
      * Returns the XUID of the connection.
      */
-    @NonNull String xuid();
+    String xuid();
 
     /**
      * Returns the version of the Bedrock client.
      */
-    @NonNull String version();
+    String version();
 
     /**
      * Returns the platform that the connection is playing on.
      */
-    @NonNull BedrockPlatform platform();
+    BedrockPlatform platform();
 
     /**
      * Returns the language code of the connection.
      */
-    @NonNull String languageCode();
+    String languageCode();
 
     /**
      * Returns the User Interface Profile of the connection.
      */
-    @NonNull UiProfile uiProfile();
+    UiProfile uiProfile();
 
     /**
      * Returns the Input Mode of the Bedrock client.
      */
-    @NonNull InputMode inputMode();
+    InputMode inputMode();
 
     /**
      * Returns whether the connection is linked.
@@ -99,7 +98,7 @@ public interface Connection {
      * @param form the form to send
      * @return whether the form was successfully sent
      */
-    boolean sendForm(@NonNull Form form);
+    boolean sendForm(Form form);
 
     /**
      * Sends a form to the connection and opens it.
@@ -107,7 +106,7 @@ public interface Connection {
      * @param formBuilder the formBuilder to send
      * @return whether the form was successfully sent
      */
-    boolean sendForm(@NonNull FormBuilder<?, ?, ?> formBuilder);
+    boolean sendForm(FormBuilder<?, ?, ?> formBuilder);
 
     /**
      * Transfer the connection to a server. A Bedrock player can successfully transfer to the same server they are
@@ -117,5 +116,5 @@ public interface Connection {
      * @param port    the port of the server
      * @return true if the transfer was a success
      */
-    boolean transfer(@NonNull String address, @IntRange(from = 0, to = 65535) int port);
+    boolean transfer(String address, @IntRange(from = 0, to = 65535) int port);
 }

--- a/base/src/main/java/org/geysermc/api/connection/package-info.java
+++ b/base/src/main/java/org/geysermc/api/connection/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.geysermc.api.connection;
+
+import org.jspecify.annotations.NullMarked;

--- a/base/src/main/java/org/geysermc/api/connection/package-info.java
+++ b/base/src/main/java/org/geysermc/api/connection/package-info.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
 @NullMarked
 package org.geysermc.api.connection;
 

--- a/base/src/main/java/org/geysermc/api/package-info.java
+++ b/base/src/main/java/org/geysermc/api/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.geysermc.api;
+
+import org.jspecify.annotations.NullMarked;

--- a/base/src/main/java/org/geysermc/api/package-info.java
+++ b/base/src/main/java/org/geysermc/api/package-info.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
 @NullMarked
 package org.geysermc.api;
 

--- a/base/src/main/java/org/geysermc/api/util/ApiVersion.java
+++ b/base/src/main/java/org/geysermc/api/util/ApiVersion.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
 package org.geysermc.api.util;
 
 /**

--- a/base/src/main/java/org/geysermc/api/util/BedrockPlatform.java
+++ b/base/src/main/java/org/geysermc/api/util/BedrockPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/base/src/main/java/org/geysermc/api/util/BedrockPlatform.java
+++ b/base/src/main/java/org/geysermc/api/util/BedrockPlatform.java
@@ -25,8 +25,6 @@
 
 package org.geysermc.api.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 public enum BedrockPlatform {
     UNKNOWN("Unknown"),
     GOOGLE("Android"),
@@ -62,7 +60,6 @@ public enum BedrockPlatform {
      * @param id the BedrockPlatform identifier
      * @return The BedrockPlatform or {@link #UNKNOWN} if the platform wasn't found
      */
-    @NonNull
     public static BedrockPlatform fromId(int id) {
         return id < VALUES.length ? VALUES[id] : VALUES[0];
     }

--- a/base/src/main/java/org/geysermc/api/util/InputMode.java
+++ b/base/src/main/java/org/geysermc/api/util/InputMode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/base/src/main/java/org/geysermc/api/util/InputMode.java
+++ b/base/src/main/java/org/geysermc/api/util/InputMode.java
@@ -25,8 +25,6 @@
 
 package org.geysermc.api.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 public enum InputMode {
     UNKNOWN,
     KEYBOARD_MOUSE,
@@ -42,7 +40,6 @@ public enum InputMode {
      * @param id the InputMode identifier
      * @return The InputMode or {@link #UNKNOWN} if the mode wasn't found
      */
-    @NonNull
     public static InputMode fromId(int id) {
         return VALUES.length > id ? VALUES[id] : VALUES[0];
     }

--- a/base/src/main/java/org/geysermc/api/util/UiProfile.java
+++ b/base/src/main/java/org/geysermc/api/util/UiProfile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2022 GeyserMC. http://geysermc.org
+ * Copyright (c) 2019-2026 GeyserMC. http://geysermc.org
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/base/src/main/java/org/geysermc/api/util/UiProfile.java
+++ b/base/src/main/java/org/geysermc/api/util/UiProfile.java
@@ -25,8 +25,6 @@
 
 package org.geysermc.api.util;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 public enum UiProfile {
     CLASSIC, POCKET;
 
@@ -38,7 +36,6 @@ public enum UiProfile {
      * @param id the UiProfile identifier
      * @return The UiProfile or {@link #CLASSIC} if the profile wasn't found
      */
-    @NonNull
     public static UiProfile fromId(int id) {
         return VALUES.length > id ? VALUES[id] : VALUES[0];
     }

--- a/base/src/main/java/org/geysermc/api/util/package-info.java
+++ b/base/src/main/java/org/geysermc/api/util/package-info.java
@@ -1,0 +1,4 @@
+@NullMarked
+package org.geysermc.api.util;
+
+import org.jspecify.annotations.NullMarked;

--- a/base/src/main/java/org/geysermc/api/util/package-info.java
+++ b/base/src/main/java/org/geysermc/api/util/package-info.java
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) 2026 GeyserMC. http://geysermc.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ * @author GeyserMC
+ * @link https://github.com/GeyserMC/Geyser
+ */
+
 @NullMarked
 package org.geysermc.api.util;
 

--- a/geyser-versioning.md
+++ b/geyser-versioning.md
@@ -11,7 +11,7 @@ Romantic Versions incorporates the following version scheme: HUMAN.MAJOR.MINOR
 - The **MINOR** version represents any additional functionality added in a backward-compatible manner or fix with backward-compatible bug fixes. This could also include deprecations. Minor versions will **always** be backwards compatible with each other.
 
 ## API Versions
-As Geyser has 2 separate APIs, a core project module, and often sees changes due to both Minecraft Java and Bedrock's own updates which don't necessarily follow a specific versioning sceheme, simply using Semantic Versioning is unrealistic.
+As Geyser has 2 separate APIs, a core project module, and often sees changes due to both Minecraft Java and Bedrock's own updates which don't necessarily follow a specific versioning scheme, simply using Semantic Versioning is unrealistic.
 
 To dig a bit deeper into the APIs Geyser has:
 - **Base API** is an API that is shaded into both Geyser and Floodgate. It is a shared API that developers can use when they want to create a Geyser project that may only have access to one or the other

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-version=1.0.2
+version=1.0.3
 
 org.gradle.caching=true
 org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 checkerframework = "3.19.0"
+jspecify = "1.0.0"
 cumulus  = "1.1.2"
 events = "1.1-SNAPSHOT"
 blossom = "2.1.0"
@@ -7,6 +8,7 @@ indra = "3.0.1"
 
 [libraries]
 checker-qual = { group = "org.checkerframework", name = "checker-qual", version.ref = "checkerframework" }
+jspecify = { group = "org.jspecify", name = "jspecify", version.ref = "jspecify" }
 cumulus = { group = "org.geysermc.cumulus", name = "cumulus", version.ref = "cumulus" }
 events = { group = "org.geysermc.event", name = "events", version.ref = "events" }
 


### PR DESCRIPTION
This PR switches to JSpecify for nullability annotations in the API module. All packages in the API now have a `package-info.java` file with a [`@NullMarked`](https://jspecify.dev/docs/user-guide/#nullmarked) annotation, which applies to all types in the package. This includes but is not limited to method return values, parameters, fields, generic type parameters, arrays, and more.

Because of this change, all `@NonNull` annotations have been removed, as they are no longer necessary. All `@Nullable` annotations have been replaced by JSpecify's, and those on a separate line have been moved to be in-line, as per JSpecify's standard.

Also see [Geyser#6303](https://github.com/GeyserMC/Geyser/pull/6303).

The patch version has been bumped.